### PR TITLE
Replace Travis with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["2.7", "3.11"]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools
+    - name: Run tests
+      run: python setup.py test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["2.7", "3.11"]
+        python-version: ["3.11"]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: python
-python:
-  - "2.7"
-script: python setup.py test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Oneliner-izer
 =========
 
-[![Build Status](https://travis-ci.org/csvoss/onelinerizer.svg?branch=master)](https://travis-ci.org/csvoss/onelinerizer)
+[![CI](https://github.com/csvoss/onelinerizer/actions/workflows/ci.yml/badge.svg)](https://github.com/csvoss/onelinerizer/actions/workflows/ci.yml)
 
 
 Convert any Python 2 script into a single line of code.


### PR DESCRIPTION
## Summary
- replace Travis CI with GitHub Actions
- remove obsolete `.travis.yml`
- update README badge to point at Actions

## Testing
- `python setup.py test` *(fails: SyntaxError because repo requires Python 2)*